### PR TITLE
fix(code): add link for questions and bookshelf pages to navigation

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -36,6 +36,14 @@ const config: GatsbyConfig = {
             title: `Uses`,
             slug: `/uses`,
           },
+          {
+            title: `Bookshelf`,
+            slug: `/bookshelf`,
+          },
+          {
+            title: `Questions`,
+            slug: `/questions`,
+          },
         ],
         externalLinks: [
           {


### PR DESCRIPTION
**Before this PR:**
- bookshelf and questions pages not part of navigation

**After this PR:**
- bookshelf and questions pages now part of navigation

**Reason that prompted this change:**
- Unable to find these pages otherwise