### PR TITLE
feat(config): improve page layout

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import 'katex/dist/katex.css'
 
 import { components } from '@/components/MDXComponents'
 import siteMetadata from '@/data/siteMetadata'
+import PageSimple from '@/layouts/PageSimple'
 import PostBanner from '@/layouts/PostBanner'
 import PostLayout from '@/layouts/PostLayout'
 import PostSimple from '@/layouts/PostSimple'
@@ -15,6 +16,7 @@ import { allCoreContent, coreContent, sortPosts } from 'pliny/utils/contentlayer
 
 const defaultLayout = 'PostLayout'
 const layouts = {
+  PageSimple,
   PostSimple,
   PostLayout,
   PostBanner,

--- a/data/blog/bookshelf.mdx
+++ b/data/blog/bookshelf.mdx
@@ -1,6 +1,7 @@
 ---
 title: Bookshelf
 date: 2017-01-01
+layout: PageSimple
 ---
 
 An idea inspired by https://patrickcollison.com/bookshelf

--- a/data/blog/questions.mdx
+++ b/data/blog/questions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Questions
 date: 2017-01-01
+layout: PageSimple
 ---
 
 An idea inspired by https://patrickcollison.com/questions

--- a/data/blog/uses.mdx
+++ b/data/blog/uses.mdx
@@ -1,6 +1,7 @@
 ---
 title: Uses
 date: 2017-01-01
+layout: PageSimple
 ---
 
 <h2 id="editor">Editor</h2>

--- a/layouts/PageSimple.tsx
+++ b/layouts/PageSimple.tsx
@@ -1,0 +1,73 @@
+import Comments from '@/components/Comments'
+import Link from '@/components/Link'
+import PageTitle from '@/components/PageTitle'
+import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import SectionContainer from '@/components/SectionContainer'
+import siteMetadata from '@/data/siteMetadata'
+import type { Blog } from 'contentlayer/generated'
+import { CoreContent } from 'pliny/utils/contentlayer'
+import { ReactNode } from 'react'
+
+interface LayoutProps {
+  content: CoreContent<Blog>
+  children: ReactNode
+  next?: { path: string; title: string }
+  prev?: { path: string; title: string }
+}
+
+export default function PostLayout({ content, next, prev, children }: LayoutProps) {
+  const { path, slug, date, title } = content
+
+  return (
+    <SectionContainer>
+      <ScrollTopAndComment />
+      <article>
+        <div>
+          <header>
+            <div className="space-y-1 border-b border-gray-200 pb-10 text-center dark:border-gray-700">
+              <div>
+                <PageTitle>{title}</PageTitle>
+              </div>
+            </div>
+          </header>
+          <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:divide-y-0">
+            <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
+              <div className="prose max-w-none pb-8 pt-10 dark:prose-invert">{children}</div>
+            </div>
+            {siteMetadata.comments && (
+              <div className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300" id="comment">
+                <Comments slug={slug} />
+              </div>
+            )}
+            <footer>
+              <div className="flex flex-col text-sm font-medium sm:flex-row sm:justify-between sm:text-base">
+                {prev && prev.path && (
+                  <div className="pt-4 xl:pt-8">
+                    <Link
+                      href={`/${prev.path}`}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                      aria-label={`Previous post: ${prev.title}`}
+                    >
+                      &larr; {prev.title}
+                    </Link>
+                  </div>
+                )}
+                {next && next.path && (
+                  <div className="pt-4 xl:pt-8">
+                    <Link
+                      href={`/${next.path}`}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                      aria-label={`Next post: ${next.title}`}
+                    >
+                      {next.title} &rarr;
+                    </Link>
+                  </div>
+                )}
+              </div>
+            </footer>
+          </div>
+        </div>
+      </article>
+    </SectionContainer>
+  )
+}


### PR DESCRIPTION
**Before this PR:**
- pages stored as blog posts had a blog format

**After this PR:**
- pages stored as blog posts use a simple page layout

**Reason that prompted this change:**
- 3 pages are stored as blog posts (mdx) and do not need features of a blog post like date